### PR TITLE
Make behaviour the same as normal database services again

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ class LocalStorage extends Service {
       throw new Error('The `storage` option needs to be provided');
     }
   }
-  
+
   ready() {
     if(!this.store) {
       return Promise.resolve(this._storage.getItem(this._storageKey))
@@ -20,17 +20,17 @@ class LocalStorage extends Service {
         .then(store => {
           const keys = Object.keys(store);
           const last = store[keys[keys.length - 1]];
-          
+
           // Current id is the id of the last item
           this._uId = keys.length ? last[this._id] + 1 : 0;
 
           return (this.store = store);
         });
     }
-    
+
     return Promise.resolve(this.store);
   }
-  
+
   flush(data) {
     if(!this._timeout) {
       this._timeout = setTimeout(() => {
@@ -38,54 +38,34 @@ class LocalStorage extends Service {
         delete this._timeout;
       }, this.throttle);
     }
-    
+
     return data;
   }
-  
+
   execute(method, ... args) {
     return this.ready()
       .then(() => super[method](... args));
-  }
-
-  get(id) {
-    return this.ready()
-      .then(() => {
-        return Promise.resolve(this.store[id]);
-      });
   }
 
   find(... args) {
     return this.execute('find', ... args);
   }
 
-  // Create without hooks and mixins that can be used internally
-  _create(data) {
-    let id = data[this._id] || (this._uId + 1);
-
-    // If the item already exists then just update it.
-    if (this.store[id]) {
-      return this.update(id, data);
-    }
-
-    // otherwise call our original _create method
-    return super._create(data);
-  }
-  
   create(... args) {
     return this.execute('create', ... args)
       .then(data => this.flush(data));
   }
-  
+
   patch(... args) {
     return this.execute('patch', ... args)
       .then(data => this.flush(data));
   }
-  
+
   update(... args) {
     return this.execute('update', ... args)
       .then(data => this.flush(data));
   }
-  
+
   remove(... args) {
     return this.execute('remove', ... args)
       .then(data => this.flush(data));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,7 @@
 /*jshint expr: true*/
 
-// import { base, example } from 'feathers-service-tests';
-// import errors from 'feathers-errors';
-import { example } from 'feathers-service-tests';
+import { base, example } from 'feathers-service-tests';
+import errors from 'feathers-errors';
 import feathers from 'feathers';
 import assert from 'assert';
 import server from './test-app';
@@ -43,19 +42,19 @@ describe('Feathers Localstorage Service', () => {
   it('is CommonJS compatible', () => {
     assert.equal(typeof require('../lib'), 'function');
   });
-  
+
   it('loads and sets data in storage', done => {
     const name = 'test-storage';
-    
+
     localstorage.setItem(name, '{ "0": { "id": 0, "text": "test 0" } }');
-    
+
     const app = feathers()
       .use('/messages', service({
         name,
         storage: localstorage
       }));
     const messageService = app.service('messages');
-      
+
     messageService.create({
       text: 'testing 1'
     }).then(() => messageService.create({
@@ -63,7 +62,7 @@ describe('Feathers Localstorage Service', () => {
     })).then(() => {
       return new Promise((resolve) => {
         setTimeout(() => {
-          
+
           const data = JSON.parse(localstorage.getItem(name));
           assert.deepEqual(data, {
             0: {
@@ -88,7 +87,7 @@ describe('Feathers Localstorage Service', () => {
     }).then(() => {
       return new Promise((resolve) => {
         setTimeout(() => {
-          
+
           const data = JSON.parse(localstorage.getItem(name));
           assert.deepEqual(data, {
             2: {
@@ -102,7 +101,7 @@ describe('Feathers Localstorage Service', () => {
     }).then(done, done);
   });
 
-  // base(people, _ids, errors);
+  base(people, _ids, errors);
 });
 
 describe('Localstorage service example test', () => {


### PR DESCRIPTION
I have some changes for `feathers-authentication/client` incoming which does not require `feathers-localstorage` to behave differently than the normal `feathers-memory`. This reverts the changes we had to do and closes #6.