### PR TITLE
readme links to the wrong version of example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ app.listen(port, function() {
 });
 ```
 
-You can run this example with `npm start` from the cloned repository and going to [localhost:3030/messages](http://localhost:3030/messages). You will see the test Message that we created at the end of that file.
+You can run the example with `npm start` from the cloned repository and going to [localhost:3030/todos](http://localhost:3030/todos). You will see the test Message that we created at the end of that file.
 
 ## License
 


### PR DESCRIPTION
Looks like messages was replaced with a todo.
